### PR TITLE
Fixing dependencies

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -6,4 +6,4 @@
 autopublish
 insecure
 preserve-inputs
-meteor-mocha-web
+mocha-web

--- a/smart.json
+++ b/smart.json
@@ -4,8 +4,6 @@
     "branch": "master"
   },
   "packages": {
-    "meteor-mocha-web": {
-      "path": "../madeye/meteor-mocha-web"
-    }
+    "mocha-web": {}
   }
 }

--- a/smart.lock
+++ b/smart.lock
@@ -6,13 +6,13 @@
   },
   "dependencies": {
     "basePackages": {
-      "meteor-mocha-web": {
-        "path": "../madeye/meteor-mocha-web"
-      }
+      "mocha-web": {}
     },
     "packages": {
-      "meteor-mocha-web": {
-        "path": "../madeye/meteor-mocha-web"
+      "mocha-web": {
+        "git": "https://github.com/mad-eye/meteor-mocha-web.git",
+        "tag": "v0.0.1",
+        "commit": "1edfc84969fcdd3edc05c4a31668199276594ab5"
       }
     }
   }


### PR DESCRIPTION
Fixing dependencies. No more local `meteor-mocha-web` dependency, now using meteorite repository: `mocha-web`.
