### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and added a couple demo tests.
 
 To run it with tests, use:
 ```
-METEOR_MOCHA_TEST_DIRS=tests meteor
+METEOR_MOCHA_TEST_DIR=tests mrt
 ```
 
 Notice that running it with a plain `meteor` command will run it without the


### PR DESCRIPTION
1. Variable name typo:
   
   ```
   METEOR_MOCHA_TEST_DIR undefined, not including meteor-mocha-web files
   ```
2. Can't run it with just meteor, but works with mrt:
   
   ```
   Error: The package named mocha-web does not exist
   ```
