### PR TITLE
Update mocha-web package

### DIFF
--- a/smart.lock
+++ b/smart.lock
@@ -11,8 +11,8 @@
     "packages": {
       "mocha-web": {
         "git": "https://github.com/mad-eye/meteor-mocha-web.git",
-        "tag": "v0.0.1",
-        "commit": "1edfc84969fcdd3edc05c4a31668199276594ab5"
+        "tag": "v0.1.0",
+        "commit": "540fd609af4e4cfa921a1ef1151bee542d2e06a4"
       }
     }
   }


### PR DESCRIPTION
Currently failing to run with tests because of [this](https://github.com/mad-eye/meteor-mocha-web/commit/da92a28dfdbc566a9c9a26482e16d5aeb03bed14)
